### PR TITLE
Specify inc::Module::Install as a dependency.

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -6,11 +6,12 @@ author:
 build_requires:
   ExtUtils::MakeMaker: 6.59
   Test::More: 0
+  inc::Module::Install: 0
 configure_requires:
   ExtUtils::MakeMaker: 6.59
 distribution_type: module
 dynamic_config: 1
-generated_by: 'Module::Install version 1.17'
+generated_by: 'Module::Install version 1.19'
 license: perl
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,6 +8,7 @@ license  'perl';
 repository 'https://github.com/Mons/lib-abs';
 
 build_requires 'Test::More';
+build_requires 'inc::Module::Install';
 
 requires Cwd => '3.12'; # FreeBDS: devel/p5-PathTools
 auto_provides;


### PR DESCRIPTION
Makefile.PL requires inc::Module::Install but that module isn't listed as a dependency, so tools like cpanm don't know to fetch it automatically, and installing lib::abs fails on e.g. fresh installs of Perl.